### PR TITLE
Added support for multiple captions in regular inline images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 **/__pycache__
 build/
 dist/
+venv/

--- a/tests/test.py
+++ b/tests/test.py
@@ -80,6 +80,48 @@ class Tests(unittest.TestCase):
             '<p>\n<figure class="class"><img src="foo.png" /><figcaption>caption</figcaption></figure>\n</p>'
         )
 
+    def test_multiple_captions(self):
+        md = markdown.Markdown(extensions=['markdown_captions'])
+
+        # two captioned img
+        self.assertEqual(
+            md.convert('![caption1][caption2](foo.png)'),
+            '<p>\n<figure><img src="foo.png" /><figcaption>caption1</figcaption>\n<figcaption>caption2</figcaption>\n</figure>\n</p>'
+        )
+
+        # three captioned img
+        self.assertEqual(
+            md.convert('![caption1][caption2][caption3](foo.png)'),
+            '<p>\n<figure><img src="foo.png" /><figcaption>caption1</figcaption>\n<figcaption>caption2</figcaption>\n<figcaption>caption3</figcaption>\n</figure>\n</p>'
+        )
+
+    def test_multiple_captions_attr(self):
+        md = markdown.Markdown(extensions=['markdown_captions', 'attr_list'])
+
+        # multiple captions but only first classed
+        self.assertEqual(
+            md.convert('![caption]{: .class}(foo.png)'),
+            '<p>\n<figure><img src="foo.png" /><figcaption class="class">caption</figcaption>\n</figure>\n</p>'
+        )
+
+        # multiple captions but only second classed
+        self.assertEqual(
+            md.convert('![caption]{: .class}[caption2](foo.png)'),
+            '<p>\n<figure><img src="foo.png" /><figcaption class="class">caption</figcaption>\n<figcaption>caption2</figcaption>\n</figure>\n</p>'
+        )
+
+        # multiple classed captions img
+        self.assertEqual(
+            md.convert('![caption]{: .class}[caption2]{: .class2}(foo.png)'),
+            '<p>\n<figure><img src="foo.png" /><figcaption class="class">caption</figcaption>\n<figcaption class="class2">caption2</figcaption>\n</figure>\n</p>'
+        )
+
+        # multiple classed captions and classed figure
+        self.assertEqual(
+                md.convert('![caption]{: .class}[caption2]{: .class2}(foo.png){: #figure}'),
+            '<p>\n<figure id="figure"><img src="foo.png" /><figcaption class="class">caption</figcaption>\n<figcaption class="class2">caption2</figcaption></figure>\n</p>'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
- Added support for multiple captions: `![caption1][caption2](foo.png)`
- Added support for caption class with attr_list: `![caption1]{: .class}(foo.png)`
- attr_list can be specified in all captions
- Added venv/ directory to .gitignore

That would resolve #9.

Multiple captions would be only available in regular image syntax:
```
![caption1][caption2](foo.png)
```
